### PR TITLE
* Added the package.json for the jquery todo app that the CefSharp br…

### DIFF
--- a/CefSharpWinFormToDo/todomvc/jquery/package.json
+++ b/CefSharpWinFormToDo/todomvc/jquery/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "dependencies": {
+    "todomvc-common": "~1.0.1",
+    "todomvc-app-css": "~1.0.1",
+    "jquery": "~2.1.1",
+    "handlebars": "~2.0.0",
+    "director": "~1.2.2"
+  }
+}


### PR DESCRIPTION
…owser loads... Note: cd CefSharpWinFormToDo\todomvc\jquery then 'npm install'

Seems like this is a missing file.  Perhaps as well the nuget package MSBuild.Npm could be added so that a clone and build would work.